### PR TITLE
Update main.tf

### DIFF
--- a/solutions/delivery/application_delivery_controller/nginx/kic/aws/main.tf
+++ b/solutions/delivery/application_delivery_controller/nginx/kic/aws/main.tf
@@ -81,7 +81,7 @@ module "eks" {
   cluster_endpoint_private_access      = false
   cluster_endpoint_public_access       = true
   cluster_endpoint_public_access_cidrs = [var.adminSourceCidr]
-  config_output_path                   = "${path.module}/cluster-config"
+  kubeconfig_output_path               = "${path.module}/cluster-config"
 }
 
 // jumphost


### PR DESCRIPTION
Fix for config name renamed to kubeconfig_output_path. This appears to be the only bug preventing deployment of DigitX aws/kic solution. Link to module change  https://github.com/terraform-aws-modules/terraform-aws-eks/commit/876536209304a4cb7d7f4e189e527dec80e5b3d5